### PR TITLE
[1.x] Missing use statement for SubscriptionPaymentFailed

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -10,6 +10,7 @@ use Laravel\Paddle\Customer;
 use Laravel\Paddle\Events\PaymentSucceeded;
 use Laravel\Paddle\Events\SubscriptionCancelled;
 use Laravel\Paddle\Events\SubscriptionCreated;
+use Laravel\Paddle\Events\SubscriptionPaymentFailed;
 use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
 use Laravel\Paddle\Events\SubscriptionUpdated;
 use Laravel\Paddle\Events\WebhookHandled;


### PR DESCRIPTION
Inside the ```handleSubscriptionPaymentFailed``` method the event signature was not imported.
